### PR TITLE
fix a bug which make a common 404 page

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,12 +4,18 @@ import { handleInitialData } from "../actions/shared";
 import Login from "./Login";
 import QuestionLists from "./QuestionLists";
 import styled from "styled-components";
-import { BrowserRouter as Router, Route, Redirect } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Redirect,
+  Switch
+} from "react-router-dom";
 import Navbar from "./Navbar";
 import AddQuestion from "./AddQuestion";
 import Leaderboard from "./Leaderboard";
 import Polling from "./Polling";
 import LoadingBar from "react-redux-loading";
+import NotFound from "./NotFound";
 
 function PrivateRoute({ children, authedUser, ...rest }) {
   return (
@@ -38,31 +44,36 @@ class App extends Component {
           <LoadingBar />
           <Container>
             <Navbar />
-            <Route path="/" exact>
-              <Login />
-            </Route>
-            <PrivateRoute
-              exact
-              authedUser={this.props.authedUser}
-              path="/questions"
-            >
-              <QuestionLists />
-            </PrivateRoute>
-            <PrivateRoute
-              authedUser={this.props.authedUser}
-              path="/questions/:question_id"
-            >
-              <Polling />
-            </PrivateRoute>
-            <PrivateRoute authedUser={this.props.authedUser} path="/add">
-              <AddQuestion />
-            </PrivateRoute>
-            <PrivateRoute
-              authedUser={this.props.authedUser}
-              path="/leaderboard"
-            >
-              <Leaderboard />
-            </PrivateRoute>
+            <Switch>
+              <Route path="/" exact>
+                <Login />
+              </Route>
+              <PrivateRoute
+                authedUser={this.props.authedUser}
+                path="/questions"
+                exact
+              >
+                <QuestionLists />
+              </PrivateRoute>
+              <PrivateRoute
+                authedUser={this.props.authedUser}
+                path="/questions/:question_id"
+              >
+                <Polling />
+              </PrivateRoute>
+              <PrivateRoute authedUser={this.props.authedUser} path="/add">
+                <AddQuestion />
+              </PrivateRoute>
+              <PrivateRoute
+                authedUser={this.props.authedUser}
+                path="/leaderboard"
+              >
+                <Leaderboard />
+              </PrivateRoute>
+              <Route path="*">
+                <NotFound />
+              </Route>
+            </Switch>
           </Container>
         </Fragment>
       </Router>

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -83,13 +83,13 @@ export default Login;
 
 const LoginContainer = styled.div`
   width: 700px;
-  height: 500px;
   border: solid;
   border-width: 2px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  padding-bottom: 30px;
 `;
 
 const Title = styled.div`

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+const NotFound = () => {
+  const { pathname } = useLocation();
+
+  return (
+    <div>
+      <h3>
+        404 - Not Found <code>{pathname}</code>
+      </h3>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/src/components/Polling.js
+++ b/src/components/Polling.js
@@ -5,13 +5,29 @@ import { connect } from "react-redux";
 import PollingQuestion from "./PollingQuestion";
 import PollingResult from "./PollingResult";
 import { withRouter } from "react-router";
+import NotFound from "./NotFound";
 
 class Polling extends Component {
+  findCurrentQuestion = question_id => {
+    const { questions } = this.props;
+    let isNotFound = true;
+    Object.keys(questions).forEach(key => {
+      if (key === question_id) {
+        isNotFound = false;
+      }
+    });
+
+    return isNotFound;
+  };
+
   render() {
-    // const { haveAnswer, user, question } = this.props;
     const { users, questions, authedUser } = this.props;
 
     const { question_id } = this.props.match.params;
+
+    const isNotFound = this.findCurrentQuestion(question_id);
+
+    if (isNotFound) return <NotFound />;
 
     let question;
 


### PR DESCRIPTION
The app crashes whenever a user tries to visit any newly added
(or non-existent) poll details page directly via the address bar.

Remember that the newly added poll would be non-existent at their URL
due to the nature of how the backend is set up in the application.
The value of questions[question_id] would be undefined for such polls.